### PR TITLE
Fix to allow contextual menu to show on modal controllers

### DIFF
--- a/Classes/BAMContextualMenu.m
+++ b/Classes/BAMContextualMenu.m
@@ -119,7 +119,11 @@
         angleOffset = 0.0;
         currentlyHighlightedMenuItemIndex = NSNotFound;
         
-        rootView = [[[[[UIApplication sharedApplication] delegate] window] rootViewController] view];
+        UIViewController* rootController = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+        while (rootController.presentedViewController != nil) {
+            rootController = rootController.presentedViewController;
+        }
+        rootView = [rootController view];
         
         shadowView = [[UIView alloc] initWithFrame:rootView.bounds];
         shadowView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.4f];


### PR DESCRIPTION
`rootView` is obtained by getting the `UIWindow` `rootViewController`, but if there's a modal controller shown over that controller, it will not show. This fixes the issue by obtaining the topmost modal view controller, if any.
